### PR TITLE
Updated atp-view.coffee

### DIFF
--- a/keymaps/atp.cson
+++ b/keymaps/atp.cson
@@ -14,7 +14,6 @@
   'cmd-shift-k': 'atom-terminal-panel:prev'
   'cmd-shift-x': 'atom-terminal-panel:destroy'
   'ctrl-`': 'atom-terminal-panel:toggle'
-  'ctrl': 'atom-terminal-panel:toggle-autocompletion'
 
 '.platform-linux atom-workspace, .platform-win32 atom-workspace':
   'shift-enter': 'atom-terminal-panel:toggle'
@@ -23,11 +22,11 @@
   'alt-shift-k': 'atom-terminal-panel:prev'
   'alt-shift-x': 'atom-terminal-panel:destroy'
   'ctrl-`': 'atom-terminal-panel:toggle'
-  'ctrl': 'atom-terminal-panel:toggle-autocompletion'
 
 '.atp-panel':
   'cmd-c': 'native!'
   'ctrl-c': 'native!'
+  'ctrl': 'atom-terminal-panel:toggle-autocompletion'
 
 '.atp-panel-body':
   'escape': 'atom-terminal-panel:toggle'

--- a/lib/atp-core.coffee
+++ b/lib/atp-core.coffee
@@ -94,19 +94,18 @@ class ATPCore
         console.log 'atp-core cannot create default terminal commands JSON file', e.message
 
   reload: () ->
-    @state.opended = false
+    @state.opened = false
     @init()
 
   init: () ->
-    if not @state.opended
+    if not @state.opened
       @state.opened = true
       @state.statePath = dirname(atom.config.getUserConfigPath()) + '/terminal-commands.json'
       try
         @state.config = JSON.parse fs.readFileSync @state.statePath
       catch e
         console.log 'atp-core cannot reload terminal config file: invalid content', e.message
-        atom.notifications.addWarning "atom-terminal-panel: Could not load the config file. The new file will be created. Reason: "+e.message
-        @state.opened = no
+        atom.notifications.addError 'atom-terminal-panel: Could not load the config file.', {detail:e.message}
       if not @state.opened
         @createDefaultCommandsFile()
         @state.opened = true

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -394,24 +394,29 @@ class ATPOutputView extends View
       @cd [CURRENT_LOCATION]
 
   getCurrentFileName: ()->
-    current_file = @getCurrentFilePath()
+    current_file = @getCurrentFile()
     if current_file != null
-      matcher = /(.*:)((.*)\\)*/ig
-      return current_file.replace matcher, ""
+      current_file.getBaseName()
     return null
 
   getCurrentFileLocation: ()->
-    if @getCurrentFilePath() == null
-      return null
-    return  @util.replaceAll(@getCurrentFileName(), "", @getCurrentFilePath())
+    current_file = @getCurrentFile()
+    if current_file?
+      return current_file.getPath().replace ///#{current_file.getBaseName()}$///, ""
 
   getCurrentFilePath: ()->
+    file = @getCurrentFile()
+    if file?
+      return file.getPath()
+    return null
+
+  getCurrentFile: ()->
     if not atom.workspace?
       return null
     te = atom.workspace.getActiveTextEditor()
     if te?
       if te.getPath()?
-        return te.getPath()
+        return te.buffer.file
     return null
 
 

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -127,7 +127,6 @@ class ATPOutputView extends View
     @onCommand 'update'
 
   showSettings: () ->
-    ATPCore.reload()
     setTimeout () =>
       panelPath = atom.packages.resolvePackagePath 'atom-terminal-panel'
       atomPath = resolve panelPath+'/../..'

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -395,8 +395,8 @@ class ATPOutputView extends View
 
   getCurrentFileName: ()->
     current_file = @getCurrentFile()
-    if current_file != null
-      current_file.getBaseName()
+    if current_file?
+      return current_file.getBaseName()
     return null
 
   getCurrentFileLocation: ()->
@@ -405,9 +405,9 @@ class ATPOutputView extends View
       return current_file.getPath().replace ///#{current_file.getBaseName()}$///, ""
 
   getCurrentFilePath: ()->
-    file = @getCurrentFile()
-    if file?
-      return file.getPath()
+    current_file = @getCurrentFile()
+    if current_file?
+      return current_file.getPath()
     return null
 
   getCurrentFile: ()->

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -735,7 +735,7 @@ class ATPOutputView extends View
     @message '\n'
     @putInputBox()
 
-  adjustWindowHeight: ->
+  setMaxWindowHeight: ->
     maxHeight = atom.config.get('atom-terminal-panel.WindowHeight')
     @cliOutput.css("max-height", "#{maxHeight}px")
     $('.terminal-input').css("max-height", "#{maxHeight}px")
@@ -820,6 +820,7 @@ class ATPOutputView extends View
     if lastOpenedView and lastOpenedView != this
       lastOpenedView.close()
     lastOpenedView = this
+    @setMaxWindowHeight()
     @scrollToBottom()
     @statusView.setActiveCommandView this
     @focusInputBox()


### PR DESCRIPTION
moveToCurrentDirectory in atp-view.coffee was not working on my mac so
I found the culprit and wrote fixed the script. I’m assuming that it
will work universally now but I could be mistaken. Someone will need to
test it on Windows.

The problem was the regex in the getCurrentFileName not matching the
file path correctly. Fixed it by getting the file object from the
activeTextEditor and grabbing the base name. Works properly now on my Mac.

This is my first pull request, so I'm sorry if I'm did something wrong. I'm hoping this helps.