### PR TITLE
Improve terminal status bar

### DIFF
--- a/keymaps/atp.cson
+++ b/keymaps/atp.cson
@@ -10,16 +10,16 @@
 '.platform-darwin atom-workspace':
   'shift-enter': 'atom-terminal-panel:toggle'
   'cmd-shift-t': 'atom-terminal-panel:new'
-  'cmd-shift-j': 'atom-terminal-panel:next'
-  'cmd-shift-k': 'atom-terminal-panel:prev'
+  'cmd-shift-j': 'atom-terminal-panel:prev'
+  'cmd-shift-k': 'atom-terminal-panel:next'
   'cmd-shift-x': 'atom-terminal-panel:destroy'
   'ctrl-`': 'atom-terminal-panel:toggle'
 
 '.platform-linux atom-workspace, .platform-win32 atom-workspace':
   'shift-enter': 'atom-terminal-panel:toggle'
   'alt-shift-t': 'atom-terminal-panel:new'
-  'alt-shift-j': 'atom-terminal-panel:next'
-  'alt-shift-k': 'atom-terminal-panel:prev'
+  'alt-shift-j': 'atom-terminal-panel:prev'
+  'alt-shift-k': 'atom-terminal-panel:next'
   'alt-shift-x': 'atom-terminal-panel:destroy'
   'ctrl-`': 'atom-terminal-panel:toggle'
 

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -819,6 +819,7 @@ class ATPOutputView extends View
     if lastOpenedView and lastOpenedView != this
       lastOpenedView.close()
     lastOpenedView = this
+    @statusIcon.addClass 'active'
     @setMaxWindowHeight()
     @scrollToBottom()
     @statusView.setActiveCommandView this
@@ -864,6 +865,7 @@ class ATPOutputView extends View
     else
       @detach()
       lastOpenedView = null
+    @statusIcon.removeClass 'active'
 
 
   toggle: ->

--- a/styles/atp.less
+++ b/styles/atp.less
@@ -144,6 +144,12 @@
   .status-ignored {
     opacity: 0.5;
   }
+  .icon-terminal {
+    opacity: 0.4;
+    &.active {
+      opacity: 1;
+    }
+  }
   .status-running {
     color: hsl(180, 1, 0.5);
   }


### PR DESCRIPTION
Improve the terminal status bar by displaying which terminal is currently active. Terminal switching key binds swapped in order to match the direction of the active terminal.