### PR TITLE
Add ps-tree dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ansi-html-stream": "0.0.3",
     "atom-space-pen-views": "^2.0.3",
     "jquery-autocomplete-js": "^1.0.6",
-    "iconv-lite": "^0.4.7"
+    "iconv-lite": "^0.4.7",
+    "ps-tree": "^1.0.0"
   }
 }


### PR DESCRIPTION
The package.json file was missing the ps-tree dependency for process
killing. After adding the dependency, process trees appear to be
killed. This fixes isis97/atom-terminal-panel#51.