### PR TITLE
Fix usage of extname, dirname when there is no project path

### DIFF
--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -1317,7 +1317,9 @@ class ATPOutputView extends View
 
   getCwd: ->
     if not atom.project?
-      return null
+      return @userHome
+    if not atom.project.getPaths()[0]?
+      return @userHome
     extFile = extname atom.project.getPaths()[0]
 
     if extFile == ""


### PR DESCRIPTION
Fix #115 and all the many other duplicates. 

When Atom is opened without a project, `atom.project.getPaths()[0]` is undefined and raises an error in the Atom deprecation cop. Return `@userHome` in this case. Do not return null because functions downstream of `getCwd` expect a string. 