### PR TITLE
Add ability to register local command keys in atom workspace

### DIFF
--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -338,6 +338,21 @@ class ATPOutputView extends View
               @open()
               @onCommand action[1]
             atom.commands.add 'atom-workspace', obj
+            
+    # add actions for local commands if specified
+    # command body should have key "action": action_name
+    # then keymap can have key-combo: atom-terminal-panel:action_name
+    for cmd_name, cmd_body of @localCommands
+      action = cmd_body.action
+      if action?
+        obj = {}
+        obj['atom-terminal-panel:'+action] = (() =>
+          cmd_name2 = cmd_name  # inner scoped variable
+          return () =>
+            @open()
+            @onCommand cmd_name2
+        )()
+        atom.commands.add 'atom-workspace', obj
 
     if atom.workspace?
       eleqr = atom.workspace.getActivePaneItem() ? atom.workspace


### PR DESCRIPTION
As far as I can tell, local commands (plugins) cannot be assigned to atom commands for the purpose of keymapping. For example, it would be nice to be able to map the "compile" command to a keyboard shortcut. This PR adds an optional field to the command body called "action" that specifies the name to associate with the command for use in the keymap.

Example in the command plugin `index.coffee`:
```coffeescript
  "compile":
    "description": "Compiles the currently opened C/C++ file using g++."
    "command": (state, args)->
      [cut]
      state.exec "#{COMPILER_NAME} #{COMPILER_FLAGS} \"#{SOURCE_FILE}\" -o \"#{TARGET_FILE}\" #{ADDITIONAL_FLAGS}", args, state
      return ""
    "action": "run-compile"
```

And in the keymap `atp.cson` or Atom user keymap:
```cson
'.platform-darwin atom-workspace':
  [cut]
  'ctrl-`': 'atom-terminal-panel:toggle'
  'ctrl-shift-c': 'atom-terminal-panel:run-compile'
```

The key combo "ctrl-shift-c" would then run the "compile" command.
